### PR TITLE
feat: make compatible with foundry V9

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -50,7 +50,7 @@
   "FXMASTER.Ease": "Ease",
   "FXMASTER.EaseHint": "Speed animation easing function",
   "FXMASTER.PermissionCreate": "Use FXMaster special effects",
-  "FXMASTER.PermissionCreateHint": "Allow usage of FXMaster special effects through the scene controls.",
+  "FXMASTER.PermissionCreateHint": "Allow users with the selected role or above to use FXMaster special effects through the scene controls.",
   "FXMASTER.MaskWeather": "Mask FXMaster Weather",
   "FXMASTER.CastStatic": "Face target",
   "FXMASTER.CastThrow": "Throw to target",

--- a/src/lang/es.json
+++ b/src/lang/es.json
@@ -41,6 +41,6 @@
   "FXMASTER.Ease": "Ease",
   "FXMASTER.EaseHint": "Función de redución de la animación de velocidad",
   "FXMASTER.PermissionCreate": "Usar efectos especiales FXMaster",
-  "FXMASTER.PermissionCreateHint": "Permite usar los efectos especiales FXMaster en los controles de escena",
+  "FXMASTER.PermissionCreateHint": "Permitir a los usuarios con el rol seleccionado o superior utilizar los efectos especiales de FXMaster a través de los controles de la escena.",
   "FXMASTER.MaskWeather": "Enmascarar climatología FXMaster"
 }

--- a/src/lang/fr.json
+++ b/src/lang/fr.json
@@ -47,7 +47,7 @@
   "FXMASTER.AnimationDelay": "Délai",
   "FXMASTER.Ease": "Ease",
   "FXMASTER.PermissionCreate": "Autoriser les effets spéciaux FXMaster",
-  "FXMASTER.PermissionCreateHint": "Autorise l'utilisation des effets spéciaux de FXMaster grâce aux contrôles de scène.",
+  "FXMASTER.PermissionCreateHint": "Permettre aux utilisateurs ayant le rôle sélectionné ou supérieur d'utiliser les effets spéciaux de FXMaster par le biais des commandes de scène.",
   "FXMASTER.MaskWeather": "Masque la Météo FXMaster",
   "FXMASTER.CastStatic": "En direction de la cible",
   "FXMASTER.CastThrow": "En lançant vers la cible",

--- a/src/module/controls.js
+++ b/src/module/controls.js
@@ -16,7 +16,7 @@ function getSceneControlButtons(controls) {
     title: "CONTROLS.Effects",
     icon: "fas fa-magic",
     layer: "specials",
-    visible: game.user.can("EFFECT_CREATE") || game.user.isGM,
+    visible: game.user.role >= game.settings.get("fxmaster", "permission-create"),
     tools: [
       {
         name: "specials",

--- a/src/module/fxmaster.js
+++ b/src/module/fxmaster.js
@@ -15,21 +15,9 @@ window.FXMASTER = {
 };
 
 function registerLayer() {
-  CONFIG.Canvas.layers = foundry.utils.mergeObject(CONFIG.Canvas.layers, {
-    fxmaster: WeatherLayer,
-    specials: SpecialsLayer,
-  });
-  // Overriding other modules if needed
-  if (!Object.is(Canvas.layers, CONFIG.Canvas.layers)) {
-    console.error("Possible incomplete layer injection by other module detected!...");
-
-    const layers = Canvas.layers;
-    Object.defineProperty(Canvas, "layers", {
-      get: function () {
-        return foundry.utils.mergeObject(layers, CONFIG.Canvas.layers);
-      },
-    });
-  }
+  const isV9OrLater = game.release?.generation ?? 0 >= 9;
+  CONFIG.Canvas.layers.fxmaster = isV9OrLater ? { layerClass: WeatherLayer, group: "effects" } : WeatherLayer;
+  CONFIG.Canvas.layers.specials = isV9OrLater ? { layerClass: SpecialsLayer, group: "effects" } : SpecialsLayer;
 }
 
 function parseSpecialEffects() {
@@ -54,13 +42,6 @@ Hooks.once("init", function () {
   registerHooks();
   registerLayer();
   registerHelpers();
-
-  CONST.USER_PERMISSIONS.EFFECT_CREATE = {
-    label: "FXMASTER.PermissionCreate",
-    hint: "FXMASTER.PermissionCreateHint",
-    defaultRole: 2,
-    disableGM: false,
-  };
 
   // Adding filters, weathers and effects
   if (!CONFIG.fxmaster) CONFIG.fxmaster = {};

--- a/src/module/settings.js
+++ b/src/module/settings.js
@@ -1,11 +1,11 @@
 export const registerSettings = function () {
   game.settings.register("fxmaster", "enable", {
-    name: game.i18n.localize("FXMASTER.Enable"),
+    name: "FXMASTER.Enable",
     default: true,
     scope: "client",
     type: Boolean,
     config: true,
-    onChange: () => window.location.reload(),
+    onChange: debouncedReload,
   });
 
   game.settings.register("fxmaster", "specialEffects", {
@@ -23,4 +23,24 @@ export const registerSettings = function () {
     type: Number,
     config: false,
   });
+
+  game.settings.register("fxmaster", "permission-create", {
+    name: "FXMASTER.PermissionCreate",
+    hint: "FXMASTER.PermissionCreateHint",
+    scope: "world",
+    config: true,
+    default: foundry.CONST.USER_ROLES.ASSISTANT,
+    type: Number,
+    choices: {
+      [foundry.CONST.USER_ROLES.PLAYER]: "USER.RolePlayer",
+      [foundry.CONST.USER_ROLES.TRUSTED]: "USER.RoleTrusted",
+      [foundry.CONST.USER_ROLES.ASSISTANT]: "USER.RoleAssistant",
+      [foundry.CONST.USER_ROLES.GAMEMASTER]: "USER.RoleGamemaster",
+    },
+    onChange: debouncedReload,
+  });
 };
+
+const debouncedReload = foundry.utils.debounce(() => {
+  window.location.reload();
+}, 100);


### PR DESCRIPTION
Additionally, this introduces a new setting to set the required role to be able to create
effects.

BREAKING CHANGE: In foundry V9, it's not possible anymore to manipulate
the permissions in `CONST`. For that reason, it was necessary to switch
to using a setting instead. Unfortunately, it is not easily possible to
to migrate from the old way to the new way, so users will have to adapt
their settings to match what they had configured previously.