### PR TITLE
fix: make lighting correctly affect weather and specials

### DIFF
--- a/src/module/fxmaster.js
+++ b/src/module/fxmaster.js
@@ -17,8 +17,8 @@ window.FXMASTER = {
 };
 
 function registerLayer() {
-  CONFIG.Canvas.layers.fxmaster = isV9OrLater() ? { layerClass: WeatherLayer, group: "effects" } : WeatherLayer;
-  CONFIG.Canvas.layers.specials = isV9OrLater() ? { layerClass: SpecialsLayer, group: "effects" } : SpecialsLayer;
+  CONFIG.Canvas.layers.fxmaster = isV9OrLater() ? { layerClass: WeatherLayer, group: "primary" } : WeatherLayer;
+  CONFIG.Canvas.layers.specials = isV9OrLater() ? { layerClass: SpecialsLayer, group: "primary" } : SpecialsLayer;
 }
 
 function parseSpecialEffects() {


### PR DESCRIPTION
This is done by moving both the fxmaster layer and the specials layer to the primary
group.

Closes #149